### PR TITLE
モックサーバー起動のコマンドの追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "nuxt build",
     "start": "nuxt start",
     "generate": "nuxt generate",
+    "server": "cd mock-server/ && docker compose up",
     "lint": "eslint --ext .ts,.js,.vue --ignore-path .gitignore .",
     "lintfix": "eslint --ext .ts,.js,.vue --ignore-path .gitignore . --fix",
     "prepare": "chmod +x .githooks/pre-commit && git config --local core.hooksPath .githooks"


### PR DESCRIPTION
## やったこと
フロントでモックサーバーの起動コマンドの作成

## Usage
`frontend/` 直下で、
```
$ yarn server
```
でモックサーバーの起動

### PS
これからmock-serverをpullするとフロントの方で差分生まれるけど、
これは基本的にそのままcommitしちゃって大丈夫です
