### PR TITLE
ユーザーアイコンの編集

### DIFF
--- a/components/layout/GridContainer.vue
+++ b/components/layout/GridContainer.vue
@@ -60,10 +60,10 @@ export default defineComponent({
       }
 
       return {
-        "--baseCol": `${spCol.value}`,
+        "--spCol": `${spCol.value}`,
         "--tabletCol": `${tabletCol.value}`,
         "--pcCol": `${pcCol.value}`,
-        "--baseGap": `${spGap.value}px`,
+        "--spGap": `${spGap.value}px`,
         "--tabletGap": `${tabletGap.value}px`,
         "--pcGap": `${pcGap.value}px`,
       };

--- a/components/shared/icons/User.vue
+++ b/components/shared/icons/User.vue
@@ -18,11 +18,7 @@ type Device = {
 
 export default defineComponent({
   props: {
-    width: {
-      type: [String, Object] as PropType<string | Device>,
-      default: "100%",
-    },
-    height: {
+    size: {
       type: [String, Object] as PropType<string | Device>,
       default: "100%",
     },
@@ -32,53 +28,30 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const spWidth = ref<string>();
-    const tabletWidth = ref<string>();
-    const pcWidth = ref<string>();
-
-    const spHeight = ref<string>();
-    const tabletHeight = ref<string>();
-    const pcHeight = ref<string>();
+    const spSize = ref<string>();
+    const tabletSize = ref<string>();
+    const pcSize = ref<string>();
 
     const styles = computed(() => {
-      if (typeof props.width === "string") {
-        spWidth.value = props.width;
-        tabletWidth.value = props.width;
-        pcWidth.value = props.width;
+      if (typeof props.size === "string") {
+        spSize.value = props.size;
+        tabletSize.value = props.size;
+        pcSize.value = props.size;
       } else {
-        spWidth.value = props.width.sp;
-        pcWidth.value = props.width.pc;
+        spSize.value = props.size.sp;
+        pcSize.value = props.size.pc;
 
-        if (props.width.tablet === undefined) {
-          tabletWidth.value = props.width.pc;
+        if (props.size.tablet === undefined) {
+          tabletSize.value = props.size.pc;
         } else {
-          tabletWidth.value = props.width.tablet;
-        }
-      }
-
-      if (typeof props.height === "string") {
-        spHeight.value = props.height;
-        tabletHeight.value = props.height;
-        pcHeight.value = props.height;
-      } else {
-        spHeight.value = props.height.sp;
-        tabletHeight.value = props.height.tablet;
-        pcHeight.value = props.height.pc;
-
-        if (props.height.tablet === undefined) {
-          tabletHeight.value = props.height.pc;
-        } else {
-          tabletHeight.value = props.height.tablet;
+          tabletSize.value = props.size.tablet;
         }
       }
 
       return {
-        "--spWidth": `${spWidth.value}`,
-        "--tabletWidth": `${tabletWidth.value}`,
-        "--pcWidth": `${pcWidth.value}`,
-        "--spHeight": `${spHeight.value}`,
-        "--tabletHeight": `${tabletWidth.value}`,
-        "--pcHeight": `${pcHeight.value}`,
+        "--spSize": `${spSize.value}`,
+        "--tabletSize": `${tabletSize.value}`,
+        "--pcSize": `${pcSize.value}`,
       };
     });
 
@@ -89,20 +62,20 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .image {
-  width: var(--spWidth);
-  height: var(--spHeight);
+  width: var(--spSize);
+  height: var(--spSize);
   border: solid 2px $blue;
   border-radius: 50%;
   object-fit: cover;
 
   @include mq() {
-    width: var(--tabletWidth);
-    height: var(--tabletHeight);
+    width: var(--tabletSize);
+    height: var(--tabletSize);
   }
 
   @include mq(pc) {
-    width: var(--pcWidth);
-    height: var(--pcHeight);
+    width: var(--pcSize);
+    height: var(--pcSize);
   }
 }
 </style>

--- a/components/shared/icons/User.vue
+++ b/components/shared/icons/User.vue
@@ -1,26 +1,108 @@
 <template>
-  <img class="image" :src="avatarUrl" alt="user icon" />
+  <img class="image" :style="styles" :src="avatarUrl" alt="user icon" />
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from "@nuxtjs/composition-api";
+import {
+  computed,
+  defineComponent,
+  PropType,
+  ref,
+} from "@nuxtjs/composition-api";
+
+type Device = {
+  sp: string;
+  tablet?: string;
+  pc: string;
+};
 
 export default defineComponent({
   props: {
+    width: {
+      type: [String, Object] as PropType<string | Device>,
+      default: "100%",
+    },
+    height: {
+      type: [String, Object] as PropType<string | Device>,
+      default: "100%",
+    },
     avatarUrl: {
       type: String as PropType<string>,
       required: true,
     },
+  },
+  setup(props) {
+    const spWidth = ref<string>();
+    const tabletWidth = ref<string>();
+    const pcWidth = ref<string>();
+
+    const spHeight = ref<string>();
+    const tabletHeight = ref<string>();
+    const pcHeight = ref<string>();
+
+    const styles = computed(() => {
+      if (typeof props.width === "string") {
+        spWidth.value = props.width;
+        tabletWidth.value = props.width;
+        pcWidth.value = props.width;
+      } else {
+        spWidth.value = props.width.sp;
+        pcWidth.value = props.width.pc;
+
+        if (props.width.tablet === undefined) {
+          tabletWidth.value = props.width.pc;
+        } else {
+          tabletWidth.value = props.width.tablet;
+        }
+      }
+
+      if (typeof props.height === "string") {
+        spHeight.value = props.height;
+        tabletHeight.value = props.height;
+        pcHeight.value = props.height;
+      } else {
+        spHeight.value = props.height.sp;
+        tabletHeight.value = props.height.tablet;
+        pcHeight.value = props.height.pc;
+
+        if (props.height.tablet === undefined) {
+          tabletHeight.value = props.height.pc;
+        } else {
+          tabletHeight.value = props.height.tablet;
+        }
+      }
+
+      return {
+        "--spWidth": `${spWidth.value}`,
+        "--tabletWidth": `${tabletWidth.value}`,
+        "--pcWidth": `${pcWidth.value}`,
+        "--spHeight": `${spHeight.value}`,
+        "--tabletHeight": `${tabletWidth.value}`,
+        "--pcHeight": `${pcHeight.value}`,
+      };
+    });
+
+    return { styles };
   },
 });
 </script>
 
 <style lang="scss" scoped>
 .image {
-  width: 100%;
-  height: 100%;
+  width: var(--spWidth);
+  height: var(--spHeight);
   border: solid 2px $blue;
   border-radius: 50%;
   object-fit: cover;
+
+  @include mq() {
+    width: var(--tabletWidth);
+    height: var(--tabletHeight);
+  }
+
+  @include mq(pc) {
+    width: var(--pcWidth);
+    height: var(--pcHeight);
+  }
 }
 </style>


### PR DESCRIPTION
## やったこと
propsの`size`によってアイコンの`width, height`を管理
  デフォルトで`100%`なのでいちいち外側で別ので囲ってclass書くのはどうかなと思ったため

あと、girdContainerの修正し忘れ

## 使い方（UserIcon でimportした場合）
```vue
// 何も書かない場合　デフォルトで100%　外でlinkとかで囲うときとかに使用
<nuxt-link>
  <UserIcon :avatarUrl="avatarUrl" />
</nuxt-link>

// どの画面サイズでも一定の時（例は100px）
<UserIcon
  :avatarUrl="avatarUrl"
  size="100px"
/>

// spとpcのみ指定（タブレットの大きさはpcと同じもの）
<UserIcon
  :avatarUrl="avatarUrl"
  :size="{ sp: '100px', pc: '150px' }"
/>

// 全て指定
<UserIcon
  :avatarUrl="avatarUrl"
  :size="{ sp: '100px', tablet: '150px', pc: '200px' }"
/>
```

### PS
この書き方採用してるけど、実際これがいい書き方なのかは分からない