### PR TITLE
BaseBoxの作成

### DIFF
--- a/assets/scss/colors.scss
+++ b/assets/scss/colors.scss
@@ -8,3 +8,4 @@ $blue: #4eb2d6;
 $blue-darken: #004c6d;
 $blue-lighten: #9fd5e9;
 $red: #d93535;
+$shadow: rgba(0, 0, 0, 0.2);

--- a/components/layout/Container.vue
+++ b/components/layout/Container.vue
@@ -37,7 +37,7 @@ export default defineComponent({
   margin: 0 auto;
   padding: 44px 16px;
 
-  @include mq(pc) {
+  @include mq() {
     padding: var(--padding);
   }
 }

--- a/components/layout/GridContainer.vue
+++ b/components/layout/GridContainer.vue
@@ -60,10 +60,10 @@ export default defineComponent({
       }
 
       return {
-        "--baseCol": `${spCol.value}`,
+        "--spCol": `${spCol.value}`,
         "--tabletCol": `${tabletCol.value}`,
         "--pcCol": `${pcCol.value}`,
-        "--baseGap": `${spGap.value}px`,
+        "--spGap": `${spGap.value}px`,
         "--tabletGap": `${tabletGap.value}px`,
         "--pcGap": `${pcGap.value}px`,
       };

--- a/components/shared/BaseBox.vue
+++ b/components/shared/BaseBox.vue
@@ -53,6 +53,7 @@ export default defineComponent({
 
   &__sub {
     font-size: 1.4rem;
+    font-weight: 500;
     color: $white;
   }
 }

--- a/components/shared/BaseBox.vue
+++ b/components/shared/BaseBox.vue
@@ -47,7 +47,7 @@ export default defineComponent({
 
   &__title {
     font-size: 2rem;
-    font-weight: 400;
+    font-weight: 500;
     color: $white;
   }
 

--- a/components/shared/BaseBox.vue
+++ b/components/shared/BaseBox.vue
@@ -1,0 +1,24 @@
+<template>
+  <div class="box">
+    <FlexContainer class="box__header">
+      <h3 class="box__title">
+        <slot name="title" />
+      </h3>
+      <span class="box__sub">
+        <slot name="sub" />
+      </span>
+    </FlexContainer>
+    <slot name="content" />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "@nuxtjs/composition-api";
+import FlexContainer from "~/components/layout/FlexContainer.vue";
+
+export default defineComponent({
+  components: {
+    FlexContainer,
+  },
+});
+</script>

--- a/components/shared/BaseBox.vue
+++ b/components/shared/BaseBox.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="box">
-    <FlexContainer class="box__header">
+    <FlexContainer
+      class="box__header"
+      justifyContent="space-between"
+      alignItems="center"
+    >
       <h3 class="box__title">
         <slot name="title" />
       </h3>
@@ -22,3 +26,33 @@ export default defineComponent({
   },
 });
 </script>
+
+<style lang="scss" scoped>
+.box {
+  width: 100%;
+  border-radius: 12px;
+  background: $white;
+
+  &__header {
+    height: 36px;
+    padding: 0 16px;
+    background: $blue;
+    border-radius: 12px 12px 0 0;
+
+    @include mq() {
+      padding: 0 20px;
+    }
+  }
+
+  &__title {
+    font-size: 2rem;
+    font-weight: 400;
+    color: $white;
+  }
+
+  &__sub {
+    font-size: 1.4rem;
+    color: $white;
+  }
+}
+</style>

--- a/components/shared/BaseBox.vue
+++ b/components/shared/BaseBox.vue
@@ -32,6 +32,7 @@ export default defineComponent({
   width: 100%;
   border-radius: 12px;
   background: $white;
+  box-shadow: 0 3px 6px $shadow;
 
   &__header {
     height: 36px;

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -2,7 +2,7 @@
   <Nuxt />
 </template>
 
-<style lang="scss" scoped>
+<style lang="scss">
 html {
   background: $black-lighten-4;
   color: $black;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,18 @@
 <template>
-  <div>
-    <h1>Hello, world!</h1>
+  <div class="main">
+    <Container>
+      <h1>Hello, world!</h1>
+    </Container>
   </div>
 </template>
+
+<script lang="ts">
+import { defineComponent } from "@nuxtjs/composition-api";
+import Container from "~/components/layout/Container.vue";
+
+export default defineComponent({
+  components: {
+    Container,
+  },
+});
+</script>


### PR DESCRIPTION
solve #9 

## やったこと
BaseBoxの作成
`<slot />`で`titile`と`sub`と`content`を追加できる

## 見た目
https://user-images.githubusercontent.com/50654077/148973880-a233dab0-b348-49db-b6da-79d3e18aa1e7.mov

#### 該当コード および 使い方
```vue
<GridConteiner
  class="main__grid"
  :cols="{ sp: 1, tablet: 1, pc: 2 }"
  :gap="40"
>
  <BaseBox class="main__box">
    <template #title> タイトル </template>
    <template #content>
      <div class="main__content">中身こんな感じ</div>
    </template>
  </BaseBox>
  <BaseBox class="main__sidebar">
    <template #title> タイトル </template>
    <template #sub> ahi </template>
    <template #content>
      <div class="main__content">中身こんな感じ</div>
    </template>
  </BaseBox>
</GridConteiner>
```

